### PR TITLE
chore: optimize CI and gitignore for pnpm workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-        cache: 'npm'
     
     # Use npm in CI for maximum reliability
     - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -21,11 +21,6 @@ Thumbs.db
 .DS_Store
 Thumbs.db
 
-# Package manager files (keep one, ignore others)
-package-lock.json
-yarn.lock
-bun.lockb
-
 # Build outputs
 *.tsbuildinfo
 .nyc_output/


### PR DESCRIPTION
- Remove npm cache from CI workflow
- Clean up gitignore by removing unnecessary lock file patterns
- Keep pnpm-lock.yaml as the primary lock file
- Streamline CI for better performance