### PR TITLE
fix: use npm install instead of npm ci in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     
-    # Use npm in CI for maximum reliability
+    # Use npm install in CI
     - name: Install dependencies
-      run: npm ci
+      run: npm install
     
     - name: Run linting
       run: npm run lint
@@ -51,7 +51,7 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
     
     - name: Install dependencies
-      run: npm ci
+      run: npm install
     
     # Extract version from GitHub release tag
     - name: Update package.json version


### PR DESCRIPTION
- Change from npm ci to npm install to work with pnpm-lock.yaml
- Keep single lock file approach (pnpm-lock.yaml only)
- Avoid developer confusion from multiple lock files
- CI will generate node_modules from existing lock file
- Apply fix to both test and publish jobs